### PR TITLE
Merge from sveltejs/svelte/site v3.32.3

### DIFF
--- a/DICTIONARY.md
+++ b/DICTIONARY.md
@@ -1,0 +1,24 @@
+**※作業中**
+
+この辞書に追加した言葉や改善したい言葉があれば是非Issueを作成してください！  
+ご提案に添えるかわかりませんが、あなたの意見を聞いて会話をしたいと思っています。
+
+
+原語|日本語訳|備考
+-|-|-
+bundler plugin|バンドルプラグイン|長音(ー)を省略する。また「バンドラプラグイン」としない。
+compiler|コンパイラ|長音(ー)を省略する。
+component|コンポーネント|
+context|context|
+container|コンテナ|長音(ー)を省略する。
+development mode|development モード|
+directive/directives|ディレクティブ|
+export|エクスポート|但し`export`キーワードそのものを指している場合は`export`。
+handler|ハンドラ|長音(ー)を省略する。
+import|インポート|但し`import`キーワードそのものを指している場合は`import`。
+listen|リッスン|「リスン」としない。Vueでは「リッスン」が使用され、MDNでも「リッスン」のほうが多く使用されているため。
+prop/props|prop/props|英語のままで統一する。「プロップ」「プロップス」としない。
+property/properties|プロパティ|文脈に応じて使い分ける。
+script|script|`<script>`やJavaScriptのコードを指している場合など、原則として`script`とする。但し、文章や台詞の意味で使用されている場合は`スクリプト`でも可。
+style|style or スタイル|文脈に応じて使い分ける。`<style>`タグそのものを指している場合は`style`、cssについて書いている場合は`スタイル`など。開発者にとって自然に読めればどちらでも可。
+vanilla JS/CSS|純粋なJS/CSS|「バニラJS/CSS」としない。


### PR DESCRIPTION
v3.32.3が昨日2/11にリリースされたので、その時点の内容をマージします。
1点チュートリアルに修正がはいっているため、その対応は別途Issueを作成します。