### PR TITLE
方程式という表現を変える

### DIFF
--- a/content/tutorial/15-context/01-context-api/text.ja.md
+++ b/content/tutorial/15-context/01-context-api/text.ja.md
@@ -21,7 +21,7 @@ setContext(key, {
 
 コンテキストオブジェクトはなんでも構いません。[lifecycle functions](tutorial/onmount)のように、`setContext`と`getContext`はコンポーネントの初期化時に呼び出されなければいけません。コンポーネントがマウントされるまで`map`は作成されないので、このコンテキストオブジェクトには`map`自体ではなく`getMap`関数が含まれています。
 
-方程式の反対側の`MapMarker.svelte`では、Mapboxインスタンスへの参照を取得することができます。
+一方、`MapMarker.svelte`では、Mapboxインスタンスへの参照を取得できるようになりました。
 
 ```js
 import { getContext } from 'svelte';


### PR DESCRIPTION
> On the other side of the equation, in MapMarker.svelte, we can now get a reference to the Mapbox instance:

上記原文の `equation` の意図としては、プログラミング的解釈であるため、「代入演算子を用いた式」を指していると思います。
ただ、前の文にある `getContext` では `equation` といった表現が無く、ここで新しく出る概念でもないため、この流れのまま「一方、」としたほうが読みやすいのではないかと思いました。

https://sveltejp.dev/tutorial/context-api
https://svelte.dev/tutorial/context-api
