### PR TITLE
Use ellipsis sign instead of three middle dots

### DIFF
--- a/content/tutorial/01-introduction/05-nested-components/text.ja.md
+++ b/content/tutorial/01-introduction/05-nested-components/text.ja.md
@@ -4,7 +4,7 @@ title: Nested components
 
 アプリ全体を単一のコンポーネントにまとめるのは現実的ではありません。代わりに、他のファイルからコンポーネントをインポートして、HTML要素を使用するのと同じようにコンポーネントを使用することができます。
 
-`<script>`タグを追加して`Nested.svelte`をインポートします・・・
+`<script>`タグを追加して`Nested.svelte`をインポートします…
 
 ```html
 <script>
@@ -12,7 +12,7 @@ title: Nested components
 </script>
 ```
 
-・・・そしてそれを追加します。
+…そしてそれを追加します。
 
 ```html
 <p>This is a paragraph.</p>


### PR DESCRIPTION
`...`を`…`に統一するときに、作業漏れしていた部分の対応です。