### PR TITLE
Improve Top-page for Japanese translation site

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,84 +1,82 @@
 {
-    "languages": {
-        "en": "English",
-        "en-US": "English",
-        "en-us": "English",
-        "ja": "日本語",
-        "ja-JP": "日本語",
-        "ja-jp": "日本語"
-    },
-    "direction": "ltr",
-    "attention": {
-        "1": "This is a site for Japanese translation by Svelte Japan Community",
-        "2": "(The repository is ",
-        "3_link": "here",
-        "4": " ). ",
-        "5": "The content on this site may be out of date or incorrect.",
-        "6": "If you are looking for the official website, please visit ",
-        "7_link": "svelte.dev",
-        "8": "."
-    },
-    "title": "Svelte • Cybernetically enhanced web apps",
-    "description": "Cybernetically enhanced web apps",
-    "tagline": "Cybernetically enhanced web apps",
-    "top": {
-        "blurb": {
-            "one": {
-                "title": "Write less code",
-                "content": "Build boilerplate-free components using languages you already know — HTML, CSS and JavaScript",
-                "learn-more": "learn more"
-            },
-            "two": {
-                "title": "No virtual DOM",
-                "content": "Svelte compiles your code to tiny, framework-less vanilla JS — your app starts fast and stays fast",
-                "learn-more": "learn more"
-            },
-            "three": {
-                "title": "Truly reactive",
-                "content": "No more complex state management libraries — Svelte brings reactivity to JavaScript itself",
-                "learn-more": "learn more"
-            },
-            "what": {
-                "p1": {
-                    "first": "Svelte is a radical new approach to building user interfaces. Whereas traditional frameworks like React and Vue do the bulk of their work in the ",
-                    "second_em": "browser",
-                    "third": ", Svelte shifts that work into a ",
-                    "fourth_em": "compile step",
-                    "fifth": " that happens when you build your app."
-                },
-                "p2": "Instead of using techniques like virtual DOM diffing, Svelte writes code that surgically updates the DOM when the state of your app changes.",
-                "p3": {
-                    "first_link": "Read the introductory blog post",
-                    "second": " to learn more."
-                }
-            },
-            "how": {
-                "terminal": {
-                    "dl": {
-                        "first": "or download and extract ",
-                        "link": "this .zip file"
-                    },
-                    "ts": {
-                        "first": "to use ",
-                        "second_link": "TypeScript",
-                        "third": " run:"
-                    }
-                },
-                "p1": {
-                    "first": "See the ",
-                    "second_link": "quickstart guide",
-                    "third": " for more information."
-                },
-                "learn_link": "Learn Svelte"
-            }
+  "languages": {
+    "en": "English",
+    "en-US": "English",
+    "en-us": "English",
+    "ja": "日本語",
+    "ja-JP": "日本語",
+    "ja-jp": "日本語"
+  },
+  "direction": "ltr",
+  "attention": {
+    "1": "This is a site for Japanese translation by Svelte Japan Community",
+    "2": "(The repository is ",
+    "3_link": "here",
+    "4": " ). ",
+    "5": "If you are looking for the official website, please visit ",
+    "6": "."
+  },
+  "title": "Svelte • Cybernetically enhanced web apps",
+  "description": "Cybernetically enhanced web apps",
+  "tagline": "Cybernetically enhanced web apps",
+  "top": {
+    "blurb": {
+      "one": {
+        "title": "Write less code",
+        "content": "Build boilerplate-free components using languages you already know — HTML, CSS and JavaScript",
+        "learn-more": "learn more"
+      },
+      "two": {
+        "title": "No virtual DOM",
+        "content": "Svelte compiles your code to tiny, framework-less vanilla JS — your app starts fast and stays fast",
+        "learn-more": "learn more"
+      },
+      "three": {
+        "title": "Truly reactive",
+        "content": "No more complex state management libraries — Svelte brings reactivity to JavaScript itself",
+        "learn-more": "learn more"
+      },
+      "what": {
+        "p1": {
+          "first": "Svelte is a radical new approach to building user interfaces. Whereas traditional frameworks like React and Vue do the bulk of their work in the ",
+          "second_em": "browser",
+          "third": ", Svelte shifts that work into a ",
+          "fourth_em": "compile step",
+          "fifth": " that happens when you build your app."
+        },
+        "p2": "Instead of using techniques like virtual DOM diffing, Svelte writes code that surgically updates the DOM when the state of your app changes.",
+        "p3": {
+          "first_link": "Read the introductory blog post",
+          "second": " to learn more."
         }
-    },
-    "docs": {
-        "owner": "sveltejs",
-        "project": "svelte",
-        "path": "/site/content"
-    },
-    "tutorial": {
-        "repo_link": "https://github.com/svelte-jp/svelte-site-jp/tree/master/content/tutorial"
+      },
+      "how": {
+        "terminal": {
+          "dl": {
+            "first": "or download and extract ",
+            "link": "this .zip file"
+          },
+          "ts": {
+            "first": "to use ",
+            "second_link": "TypeScript",
+            "third": " run:"
+          }
+        },
+        "p1": {
+          "first": "See the ",
+          "second_link": "quickstart guide",
+          "third": " for more information."
+        },
+        "learn_link": "Learn Svelte"
+      }
     }
+  },
+  "docs": {
+    "owner": "sveltejs",
+    "project": "svelte",
+    "path": "/site/content"
+  },
+  "tutorial": {
+    "repo_link": "https://github.com/svelte-jp/svelte-site-jp/tree/master/content/tutorial"
+  }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -23,12 +23,12 @@
     "blurb": {
       "one": {
         "title": "Write less code",
-        "content": "あなたが既に知っている言語（HTML、CSS、JavaScript）で、ボイラープレートのないコンポーネントを作成することができます",
+        "content": "既に広く知られている言語（HTML、CSS、JavaScript）で、ボイラープレートのないコンポーネントを作成することができます",
         "learn-more": "さらに詳しく"
       },
       "two": {
         "title": "No virtual DOM",
-        "content": "Svelteは、あなたのコードをフレームワークが含まれない小さいvanilla JSにコンパイルします - アプリケーションは高速に起動し、そのスピードを維持します",
+        "content": "Svelteは、コードをフレームワークが含まれない小さいvanilla JSにコンパイルします - アプリケーションは高速に起動し、そのスピードを維持します",
         "learn-more": "さらに詳しく"
       },
       "three": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,84 +1,82 @@
 {
-    "languages": {
-        "en": "English",
-        "en-US": "English",
-        "en-us": "English",
-        "ja": "日本語",
-        "ja-JP": "日本語",
-        "ja-jp": "日本語"
-    },
-    "direction": "ltr",
-    "attention": {
-        "1": "このサイトはSvelte日本コミュニティによるSvelteの日本語サイトです",
-        "2": "（リポジトリは",
-        "3_link": "こちら",
-        "4": "）。",
-        "5": "記載されている内容は古くなっているか、または誤りがある可能性がございます。",
-        "6": "公式サイトをお探しの場合は",
-        "7_link": "svelte.dev",
-        "8": "へどうぞ。"
-    },
-    "title": "Svelte • サイバネティクスで強化されたWebアプリ",
-    "description": "サイバネティクスで強化されたWebアプリ",
-    "tagline": "サイバネティクスで強化されたWebアプリ",
-    "top": {
-        "blurb": {
-            "one": {
-                "title": "Write less code",
-                "content": "あなたが既に知っている言語（HTML、CSS、JavaScript）で、ボイラープレートのないコンポーネントを作成することができます",
-                "learn-more": "さらに詳しく"
-            },
-            "two": {
-                "title": "No virtual DOM",
-                "content": "Svelteは、あなたのコードをフレームワークが含まれない小さいvanilla JSにコンパイルします - アプリケーションは高速に起動し、そのスピードを維持します",
-                "learn-more": "さらに詳しく"
-            },
-            "three": {
-                "title": "Truly reactive",
-                "content": "もう複雑な状態管理ライブラリは必要ありません - SvelteはJavaScriptそのものにリアクティビティをもたらします",
-                "learn-more": "さらに詳しく"
-            },
-            "what": {
-                "p1": {
-                    "first": "Svelteはユーザーインタフェースを構築する先鋭的で新しいアプローチです。ReactやVueのような従来のフレームワークがその作業の大部分を",
-                    "second_em": "ブラウザー",
-                    "third": "で行うのに対し、Svelteは、その作業をアプリをビルドする際の",
-                    "fourth_em": "コンパイル時",
-                    "fifth": "に行います。"
-                },
-                "p2": "Svelteは、仮想DOMによる差分検出のようなテクニックを使用する代わりに、アプリケーションの状態が変化したときにDOMを外科的に更新するコードを生成します。",
-                "p3": {
-                    "first_link": "もっと詳しく知りたい方はこちらの紹介ブログ記事",
-                    "second": "をご覧ください。"
-                }
-            },
-            "how": {
-                "terminal": {
-                    "dl": {
-                        "first": "または、こちらのzipファイルをダウンロードして解凍してください:",
-                        "link": "zip file"
-                    },
-                    "ts": {
-                        "first": "もし",
-                        "second_link": "TypeScript",
-                        "third": "を使用する場合はこちらを実行してください"
-                    }
-                },
-                "p1": {
-                    "first": "もっと詳しく知りたい方はこちらの",
-                    "second_link": "quickstart guide",
-                    "third": "をご覧ください。"
-                },
-                "learn_link": "Svelteを学ぶ"
-            }
+  "languages": {
+    "en": "English",
+    "en-US": "English",
+    "en-us": "English",
+    "ja": "日本語",
+    "ja-JP": "日本語",
+    "ja-jp": "日本語"
+  },
+  "direction": "ltr",
+  "attention": {
+    "1": "ここはSvelte日本コミュニティによるSvelteの日本語サイトです",
+    "2": "(リポジトリは",
+    "3_link": "こちら",
+    "4": ")。",
+    "5": "公式サイトをお探しの場合は",
+    "6": "へどうぞ。"
+  },
+  "title": "Svelte • サイバネティクスで強化されたWebアプリ",
+  "description": "サイバネティクスで強化されたWebアプリ",
+  "tagline": "サイバネティクスで強化されたWebアプリ",
+  "top": {
+    "blurb": {
+      "one": {
+        "title": "Write less code",
+        "content": "あなたが既に知っている言語（HTML、CSS、JavaScript）で、ボイラープレートのないコンポーネントを作成することができます",
+        "learn-more": "さらに詳しく"
+      },
+      "two": {
+        "title": "No virtual DOM",
+        "content": "Svelteは、あなたのコードをフレームワークが含まれない小さいvanilla JSにコンパイルします - アプリケーションは高速に起動し、そのスピードを維持します",
+        "learn-more": "さらに詳しく"
+      },
+      "three": {
+        "title": "Truly reactive",
+        "content": "もう複雑な状態管理ライブラリは必要ありません - SvelteはJavaScriptそのものにリアクティビティをもたらします",
+        "learn-more": "さらに詳しく"
+      },
+      "what": {
+        "p1": {
+          "first": "Svelteはユーザーインタフェースを構築する先鋭的で新しいアプローチです。ReactやVueのような従来のフレームワークがその作業の大部分を",
+          "second_em": "ブラウザー",
+          "third": "で行うのに対し、Svelteは、その作業をアプリをビルドする際の",
+          "fourth_em": "コンパイル時",
+          "fifth": "に行います。"
+        },
+        "p2": "Svelteは、仮想DOMによる差分検出のようなテクニックを使用する代わりに、アプリケーションの状態が変化したときにDOMを外科的に更新するコードを生成します。",
+        "p3": {
+          "first_link": "もっと詳しく知りたい方はこちらの紹介ブログ記事",
+          "second": "をご覧ください。"
         }
-    },
-    "docs": {
-        "owner": "svelte-jp",
-        "project": "svelte-site-jp",
-        "path": "/content"
-    },
-    "tutorial": {
-        "repo_link": "https://github.com/svelte-jp/svelte-site-jp/tree/master/content/tutorial"
+      },
+      "how": {
+        "terminal": {
+          "dl": {
+            "first": "または、こちらのzipファイルをダウンロードして解凍してください:",
+            "link": "zip file"
+          },
+          "ts": {
+            "first": "もし",
+            "second_link": "TypeScript",
+            "third": "を使用する場合はこちらを実行してください"
+          }
+        },
+        "p1": {
+          "first": "もっと詳しく知りたい方はこちらの",
+          "second_link": "quickstart guide",
+          "third": "をご覧ください。"
+        },
+        "learn_link": "Svelteを学ぶ"
+      }
     }
+  },
+  "docs": {
+    "owner": "svelte-jp",
+    "project": "svelte-site-jp",
+    "path": "/content"
+  },
+  "tutorial": {
+    "repo_link": "https://github.com/svelte-jp/svelte-site-jp/tree/master/content/tutorial"
+  }
 }

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -27,20 +27,35 @@
 	}
 
 	.attention {
-		width: 100%;
-		max-width: 120rem;
-		padding: 2em var(--side-nav);
-		margin: 0 auto;
+		position: absolute;
+		top: var(--nav-h);
+		left: 0px;
+		padding: 1rem var(--side-nav);
 		font-size: var(--h6);
 	}
 	.attention div {
-		padding: 1em var(--side-nav);
+		padding: 0.5rem 1rem;
+		max-width: 58rem;
 		background: #eeeeee;
 		border-radius: var(--border-r);
 	}
 	.attention div p {
 		margin-bottom: 0;
 	}
+
+	@media (max-width: 440px) {
+		.attention {
+			padding: 1rem 0rem;
+			font-size: var(--code-fs);
+		}
+	}
+
+	@media (min-width: 1200px) {
+		.attention {
+			left: calc((100% - 120rem) / 2);
+		}
+	}
+
 </style>
 
 <svelte:head>
@@ -54,12 +69,9 @@
 <section class="attention">
 	<div>
 		<p>
-			{$_('attention.1', { default: 'This is an unofficial site for Japanese translation by volunteers in Svelte Japan ' })}
+			{$_('attention.1', { default: 'This is a site for Japanese translation by Svelte Japan Community' })}
 			{$_('attention.2', { default: '(The repository is ' })}<a href="https://github.com/svelte-jp/svelte-site-jp">{$_('attention.3_link', { default: 'here' })}</a>{$_('attention.4', { default: '). ' })}
-			<br/>
-			{$_('attention.5', { default: 'The content on this unofficial site may be out of date or incorrect.' })}
-			<br/>
-			{$_('attention.6', { default: 'If you are looking for the official website, please visit ' })}<a href="https://svelte.dev/">{$_('attention.7_link', { default: 'svelte.dev' })}</a>{$_('attention.8', { default: '.' })}
+			{$_('attention.5', { default: 'If you are looking for the official website, please visit ' })}<a href="https://svelte.dev/">svelte.dev</a>{$_('attention.6', { default: '.' })}
 		</p>
 	</div>
 </section>


### PR DESCRIPTION
日本語サイトの注意書きによって公式と少しレイアウトがずれているのが気になりました。

- 日本語サイト
![image](https://user-images.githubusercontent.com/29677552/122313740-bb809980-cf51-11eb-9ab5-72e8e355f7b1.png)

- 公式サイト
![image](https://user-images.githubusercontent.com/29677552/122313787-cf2c0000-cf51-11eb-8f38-2a16a2ebc0e1.png)


また、もう正式なドメインでホストできるようになり、公式の更新に対してそこまで遅れず追従できているので、不要な文言を削りました。あとは「Write less code」と「No Virtual DOM」の翻訳を少し改善しています。

- 改善後の日本語サイト
![image](https://user-images.githubusercontent.com/29677552/122314072-70b35180-cf52-11eb-885a-87d90e4afce8.png)
- 改善後の日本語サイト(モバイル)
![image](https://user-images.githubusercontent.com/29677552/122314099-7ad55000-cf52-11eb-9111-f662425fcf59.png)
