### PR TITLE
[docs]Discord のリンクを追加

### DIFF
--- a/site/content/docs/00-introduction.md
+++ b/site/content/docs/00-introduction.md
@@ -10,4 +10,4 @@ title: 始める前に (Before we begin)
 
 古いバージョンのSvelteをお使いですか？ [v2 docs](https://v2.svelte.dev)をご覧ください。
 
-> 日本語翻訳版 追記：上記のDiscordはSvelte本体のもので、英語でコミュニケーションが行われています。もし日本語で質問したり交流したいのであれば、Svelte日本のDiscordにどうぞ！
+> 日本語翻訳版 追記：上記のDiscordはSvelte本体のもので、英語でコミュニケーションが行われています。もし日本語で質問したり交流したいのであれば、[Svelte日本のDiscord](https://discord.com/invite/YTXq3ZtBbx)にどうぞ！


### PR DESCRIPTION
Docs の冒頭にある「Svelte日本のDiscord」をリンクにしました（色味が微妙ですが...） 
URL は GitHub のリンク README にあるものを使用しています
![image](https://user-images.githubusercontent.com/46585162/140535059-79424b57-4b14-4764-9ae5-01fc60a4db5d.png)


（↓ 前回コミットで PR テンプレートが英語になっていました）

---
### Before submitting the PR, please make sure you do the following
- [ ] It's  really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
