### PR TITLE
Fix broken link in 2021-11-01-whats-new-in-svelte-november-2021.md

### DIFF
--- a/site/content/blog/2021-11-01-whats-new-in-svelte-november-2021.md
+++ b/site/content/blog/2021-11-01-whats-new-in-svelte-november-2021.md
@@ -26,7 +26,7 @@ SvelteKitの完成度が[80%を超え](https://github.com/sveltejs/kit/milestone
 - `vite-plugin-svelte`では、新しい`experimental.prebundleSvelteLibraries`オプションを追加しました。このオプションは、アイコンライブラリやUIフレームワークのような多くのコンポーネントを含むSvelteライブラリのロードをより高速にします。このオプションは、`svelte.config.js`のルートで設定できます。是非お試しいただき、ご意見をお聞かせください！
 - SvelteKitは、`rel="external"`としてマークされていない限り、クライアント上のエンドポイントのみをルーティングします。 - これにより、クライアントJSのサイズが小さくなり、将来的にルーターのリファクタリングがしやすくなりました。([2656](https://github.com/sveltejs/kit/pull/2656))
 - SvelteKitがNode 12をサポートしなくなりました。([2604](https://github.com/sveltejs/kit/pull/2604))
-- SvelteKitがVite 2.6.0からVite 2.6.12にアップグレードされ、ViteがSvelteランタイムを破壊する問題が修正されました。(https://github.com/vitejs/vite/issues/4306) また、SvelteKitのテンプレートにおけるViteの問題を回避または診断しやすくするための、SvelteKitチームによる2つの修正が含まれています(https://github.com/vitejs/vite/pull/5192) および (https://github.com/vitejs/vite/pull/5193)。Vite 2.7のベータ版が公開されており、SSRの修正が追加されています。
+- SvelteKitがVite 2.6.0からVite 2.6.12にアップグレードされ、ViteがSvelteランタイムを破壊する問題が修正されました。(https://github.com/vitejs/vite/issues/4306) また、SvelteKitのテンプレートにおけるViteの問題を回避または診断しやすくするための、SvelteKitチームによる2つの修正が含まれています(https://github.com/vitejs/vite/pull/5192) および ([https://github.com/vitejs/vite/pull/5193](https://github.com/vitejs/vite/pull/5193))。Vite 2.7のベータ版が公開されており、SSRの修正が追加されています。
 
 
 SvelteおよびSvelteKitのすべての更新を確認するには、それぞれ[Svelte](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md)および[SvelteKit changelog](https://github.com/sveltejs/kit/blob/master/packages/kit/CHANGELOG.md)をご覧ください。


### PR DESCRIPTION
元の書き方ではlinkの終わりが自動的にうまく判断できないようです。

![image](https://user-images.githubusercontent.com/16508807/147302485-a6347088-d518-4024-ad5b-570d678a6a6a.png)

GitHubでも同じです。

![image](https://user-images.githubusercontent.com/16508807/147302565-54e837d4-0767-42fb-a3bd-13421785ee75.png)


このPRは明示的にlink構文を使用して問題を回避するようにします。