### PR TITLE
Fix typo in tutorial/16-special-elements/07-svelte-head

### DIFF
--- a/site/content/tutorial/16-special-elements/07-svelte-head/text.md
+++ b/site/content/tutorial/16-special-elements/07-svelte-head/text.md
@@ -10,4 +10,4 @@ title: <svelte:head>
 </svelte:head>
 ```
 
-> サーバサイドレンダリング (SSR) モードでは、`<svelte:head>` の内容は HTML の残りのHTMLとは別に返されます。
+> サーバサイドレンダリング (SSR) モードでは、`<svelte:head>` の内容は残りのHTMLとは別に返されます。


### PR DESCRIPTION
Fix small mistake in `site/content/tutorial/16-special-elements/07-svelte-head/text.md`.